### PR TITLE
Create dashboard todo list page

### DIFF
--- a/index.html
+++ b/index.html
@@ -1,0 +1,170 @@
+<!DOCTYPE html>
+<html lang="pt-BR">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Dashboard To Do List</title>
+    <link rel="preconnect" href="https://fonts.googleapis.com" />
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+    <link
+      href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&display=swap"
+      rel="stylesheet"
+    />
+    <link rel="stylesheet" href="styles.css" />
+  </head>
+  <body>
+    <main class="layout">
+      <header class="header">
+        <div>
+          <h1>Bem-vindo, Douglas!</h1>
+          <p class="subtitle">Organize seu dia e acompanhe o progresso das suas tarefas.</p>
+        </div>
+        <button class="add-task-button" type="button" id="open-task-form">+ Nova tarefa</button>
+      </header>
+
+      <section class="grid">
+        <div class="card span-2" id="status-bars-card">
+          <header class="card-header">
+            <h2>Status das tarefas</h2>
+            <span class="card-caption">Distribuição por percentual</span>
+          </header>
+          <div class="progress-list" id="progress-bars"></div>
+        </div>
+
+        <div class="card" id="task-counters-card">
+          <header class="card-header">
+            <h2>Contagem de tarefas</h2>
+            <span class="card-caption">Atualiza conforme os status</span>
+          </header>
+          <div class="counter-grid">
+            <div class="counter-item">
+              <span class="counter-label">A Fazer</span>
+              <span class="counter-value" data-status="todo">0</span>
+            </div>
+            <div class="counter-item">
+              <span class="counter-label">Progredindo</span>
+              <span class="counter-value" data-status="progress">0</span>
+            </div>
+            <div class="counter-item">
+              <span class="counter-label">Concluídas</span>
+              <span class="counter-value" data-status="done">0</span>
+            </div>
+          </div>
+        </div>
+
+        <div class="card" id="avatar-card">
+          <header class="card-header">
+            <h2>Perfil</h2>
+            <span class="card-caption">Personalize com sua foto</span>
+          </header>
+          <div class="avatar-wrapper">
+            <label for="avatar-input" class="avatar-upload">
+              <img id="avatar-preview" src="https://i.pravatar.cc/160?img=12" alt="Avatar do usuário" />
+              <span>Atualizar foto</span>
+            </label>
+            <input type="file" id="avatar-input" accept="image/*" />
+          </div>
+        </div>
+
+        <div class="card" id="weekly-calendar-card">
+          <header class="card-header">
+            <h2>Horas na semana</h2>
+            <span class="card-caption">Acompanhe a distribuição diária</span>
+          </header>
+          <div class="week-calendar" id="weekly-calendar"></div>
+        </div>
+
+        <div class="card" id="pomodoro-card">
+          <header class="card-header">
+            <h2>Time Tracker</h2>
+            <span class="card-caption">Ciclos de Pomodoro</span>
+          </header>
+          <div class="pomodoro">
+            <div class="timer-display">
+              <svg class="timer-ring" viewBox="0 0 120 120">
+                <circle class="timer-track" cx="60" cy="60" r="54"></circle>
+                <circle class="timer-progress" cx="60" cy="60" r="54"></circle>
+              </svg>
+              <div class="timer-info">
+                <span class="timer-label">Foco</span>
+                <span class="timer-value" id="timer-value">25:00</span>
+              </div>
+            </div>
+            <div class="timer-controls">
+              <button type="button" id="toggle-timer">Iniciar</button>
+              <button type="button" id="reset-timer" class="ghost">Reiniciar</button>
+            </div>
+          </div>
+        </div>
+
+        <div class="card span-2" id="percent-card">
+          <header class="card-header">
+            <h2>Percentual geral</h2>
+            <span class="card-caption">Resumo dos estados das tarefas</span>
+          </header>
+          <div class="percent-wrapper">
+            <div class="donut" id="status-donut">
+              <div class="donut-center">
+                <span>Total</span>
+                <strong id="total-tasks">0</strong>
+                <small>tarefas</small>
+              </div>
+            </div>
+            <ul class="legend" id="percent-legend"></ul>
+          </div>
+        </div>
+
+        <div class="card span-4" id="agenda-card">
+          <header class="card-header">
+            <div>
+              <h2>Agenda da semana</h2>
+              <span class="card-caption">Organize o início e término das tarefas</span>
+            </div>
+            <button class="ghost" type="button" id="toggle-form">Adicionar tarefa</button>
+          </header>
+          <form id="task-form" class="task-form" hidden>
+            <div class="form-grid">
+              <label>
+                Nome da tarefa
+                <input type="text" id="task-title" required />
+              </label>
+              <label>
+                Status
+                <select id="task-status">
+                  <option value="todo">A Fazer</option>
+                  <option value="progress">Progredindo</option>
+                  <option value="done">Concluída</option>
+                </select>
+              </label>
+              <label>
+                Dia da semana
+                <select id="task-day">
+                  <option value="segunda">Segunda</option>
+                  <option value="terca">Terça</option>
+                  <option value="quarta">Quarta</option>
+                  <option value="quinta">Quinta</option>
+                  <option value="sexta">Sexta</option>
+                </select>
+              </label>
+              <label>
+                Início
+                <input type="time" id="task-start" required />
+              </label>
+              <label>
+                Término
+                <input type="time" id="task-end" required />
+              </label>
+            </div>
+            <div class="form-actions">
+              <button type="submit">Salvar tarefa</button>
+              <button type="button" class="ghost" id="cancel-task">Cancelar</button>
+            </div>
+          </form>
+          <div class="agenda" id="agenda"></div>
+        </div>
+      </section>
+    </main>
+
+    <script src="script.js"></script>
+  </body>
+</html>

--- a/script.js
+++ b/script.js
@@ -1,0 +1,325 @@
+const STATUS_INFO = {
+  todo: { label: 'A Fazer', color: getComputedStyle(document.documentElement).getPropertyValue('--todo').trim() || '#f97316' },
+  progress: { label: 'Progredindo', color: getComputedStyle(document.documentElement).getPropertyValue('--progress').trim() || '#0ea5e9' },
+  done: { label: 'Concluída', color: getComputedStyle(document.documentElement).getPropertyValue('--done').trim() || '#22c55e' }
+};
+
+const DAY_LABELS = {
+  segunda: 'Segunda-feira',
+  terca: 'Terça-feira',
+  quarta: 'Quarta-feira',
+  quinta: 'Quinta-feira',
+  sexta: 'Sexta-feira'
+};
+
+const initialTasks = [
+  { id: crypto.randomUUID(), title: 'Planejar sprint', status: 'todo', day: 'segunda', start: '09:00', end: '10:30' },
+  { id: crypto.randomUUID(), title: 'Reunião com equipe', status: 'progress', day: 'segunda', start: '11:00', end: '12:00' },
+  { id: crypto.randomUUID(), title: 'Desenvolver feature', status: 'progress', day: 'terca', start: '13:30', end: '16:00' },
+  { id: crypto.randomUUID(), title: 'Revisão de código', status: 'todo', day: 'quarta', start: '09:30', end: '11:00' },
+  { id: crypto.randomUUID(), title: 'Testes automatizados', status: 'done', day: 'quinta', start: '10:00', end: '12:00' },
+  { id: crypto.randomUUID(), title: 'Retrospectiva', status: 'done', day: 'sexta', start: '15:00', end: '16:00' }
+];
+
+let tasks = [...initialTasks];
+
+const weeklyHours = {
+  segunda: 6,
+  terca: 7,
+  quarta: 5,
+  quinta: 6,
+  sexta: 4
+};
+
+const weeklyCalendarEl = document.getElementById('weekly-calendar');
+const progressBarsEl = document.getElementById('progress-bars');
+const donutEl = document.getElementById('status-donut');
+const legendEl = document.getElementById('percent-legend');
+const agendaEl = document.getElementById('agenda');
+const totalTasksEl = document.getElementById('total-tasks');
+const counters = document.querySelectorAll('.counter-value');
+const toggleFormBtn = document.getElementById('toggle-form');
+const openFormBtn = document.getElementById('open-task-form');
+const formEl = document.getElementById('task-form');
+const cancelFormBtn = document.getElementById('cancel-task');
+const avatarInput = document.getElementById('avatar-input');
+const avatarPreview = document.getElementById('avatar-preview');
+
+function renderWeeklyCalendar() {
+  const today = new Date();
+  const weekdays = ['domingo', 'segunda', 'terça', 'quarta', 'quinta', 'sexta', 'sábado'];
+  const normalizedWeekdays = ['segunda', 'terca', 'quarta', 'quinta', 'sexta'];
+
+  weeklyCalendarEl.innerHTML = normalizedWeekdays
+    .map((dayKey) => {
+      const normalizedToday = weekdays[today.getDay()].normalize('NFD').replace(/\p{Diacritic}/gu, '');
+      const isToday = normalizedToday === dayKey;
+      return `
+        <div class="week-day ${isToday ? 'current' : ''}">
+          <strong>${DAY_LABELS[dayKey] || dayKey}</strong>
+          <span>${weeklyHours[dayKey]} h trabalhadas</span>
+        </div>
+      `;
+    })
+    .join('');
+}
+
+function formatLabel(dayKey) {
+  return DAY_LABELS[dayKey] || dayKey;
+}
+
+function updateProgressModules() {
+  const totals = { todo: 0, progress: 0, done: 0 };
+  tasks.forEach((task) => {
+    if (totals[task.status] !== undefined) {
+      totals[task.status] += 1;
+    }
+  });
+
+  const totalTasks = tasks.length || 1;
+  totalTasksEl.textContent = tasks.length;
+
+  progressBarsEl.innerHTML = Object.entries(totals)
+    .map(([status, count]) => {
+      const percentage = Math.round((count / totalTasks) * 100);
+      return `
+        <div class="progress-item">
+          <span class="progress-label">${STATUS_INFO[status].label}</span>
+          <div class="progress-bar">
+            <div class="progress-fill" style="background:${STATUS_INFO[status].color}; width:${percentage}%"></div>
+          </div>
+          <span class="progress-value">${percentage}%</span>
+        </div>
+      `;
+    })
+    .join('');
+
+  counters.forEach((counter) => {
+    const status = counter.dataset.status;
+    counter.textContent = totals[status];
+  });
+
+  const percentages = Object.entries(totals).map(([status, count]) => ({
+    status,
+    count,
+    percentage: totalTasks === 0 ? 0 : Math.round((count / totalTasks) * 100)
+  }));
+
+  let startAngle = 0;
+  const segments = percentages
+    .map(({ status, percentage }) => {
+      const endAngle = startAngle + (360 * percentage) / 100;
+      const segment = `${STATUS_INFO[status].color} ${startAngle}deg ${endAngle}deg`;
+      startAngle = endAngle;
+      return segment;
+    })
+    .join(', ');
+
+  donutEl.style.background = percentages.every((item) => item.percentage === 0)
+    ? 'conic-gradient(#e2e8f0 0deg 360deg)'
+    : `conic-gradient(${segments})`;
+
+  legendEl.innerHTML = percentages
+    .map(({ status, percentage, count }) => `
+      <li class="legend-item">
+        <span class="legend-bullet" style="background:${STATUS_INFO[status].color}"></span>
+        <div class="legend-text">
+          <strong>${STATUS_INFO[status].label}</strong>
+          <span>${percentage}% • ${count} tarefas</span>
+        </div>
+      </li>
+    `)
+    .join('');
+}
+
+function groupTasksByDay() {
+  return tasks.reduce((acc, task) => {
+    if (!acc[task.day]) acc[task.day] = [];
+    acc[task.day].push(task);
+    acc[task.day].sort((a, b) => a.start.localeCompare(b.start));
+    return acc;
+  }, {});
+}
+
+function renderAgenda() {
+  const grouped = groupTasksByDay();
+  const dayOrder = ['segunda', 'terca', 'quarta', 'quinta', 'sexta'];
+
+  agendaEl.innerHTML = dayOrder
+    .map((dayKey) => {
+      const items = grouped[dayKey] || [];
+      if (!items.length) {
+        return `
+          <div class="agenda-day">
+            <header>
+              <h3>${formatLabel(dayKey)}</h3>
+              <span>Sem tarefas</span>
+            </header>
+          </div>
+        `;
+      }
+
+      const taskItems = items
+        .map(
+          (task) => `
+            <div class="task-item" data-id="${task.id}">
+              <div>
+                <p class="task-name">${task.title}</p>
+                <p class="task-time">${task.start} - ${task.end}</p>
+              </div>
+              <span class="task-time">${STATUS_INFO[task.status].label}</span>
+              <select class="task-status-select">
+                <option value="todo" ${task.status === 'todo' ? 'selected' : ''}>A Fazer</option>
+                <option value="progress" ${task.status === 'progress' ? 'selected' : ''}>Progredindo</option>
+                <option value="done" ${task.status === 'done' ? 'selected' : ''}>Concluída</option>
+              </select>
+            </div>
+          `
+        )
+        .join('');
+
+      return `
+        <div class="agenda-day">
+          <header>
+            <h3>${formatLabel(dayKey)}</h3>
+            <span>${items.length} ${items.length === 1 ? 'tarefa' : 'tarefas'}</span>
+          </header>
+          ${taskItems}
+        </div>
+      `;
+    })
+    .join('');
+}
+
+function updateDashboard() {
+  updateProgressModules();
+  renderAgenda();
+}
+
+function toggleForm(show) {
+  formEl.hidden = !show;
+  if (show) {
+    formEl.querySelector('#task-title').focus();
+  }
+}
+
+formEl?.addEventListener('submit', (event) => {
+  event.preventDefault();
+  const title = document.getElementById('task-title').value.trim();
+  const status = document.getElementById('task-status').value;
+  const day = document.getElementById('task-day').value;
+  const start = document.getElementById('task-start').value;
+  const end = document.getElementById('task-end').value;
+
+  if (!title || !start || !end) return;
+
+  tasks.push({ id: crypto.randomUUID(), title, status, day, start, end });
+  formEl.reset();
+  toggleForm(false);
+  updateDashboard();
+});
+
+cancelFormBtn?.addEventListener('click', () => {
+  formEl.reset();
+  toggleForm(false);
+});
+
+openFormBtn?.addEventListener('click', () => toggleForm(true));
+toggleFormBtn?.addEventListener('click', () => toggleForm(formEl.hidden));
+
+agendaEl.addEventListener('change', (event) => {
+  if (!event.target.classList.contains('task-status-select')) return;
+  const taskItem = event.target.closest('.task-item');
+  const taskId = taskItem?.dataset.id;
+  if (!taskId) return;
+
+  tasks = tasks.map((task) => (task.id === taskId ? { ...task, status: event.target.value } : task));
+  updateDashboard();
+});
+
+avatarInput?.addEventListener('change', (event) => {
+  const file = event.target.files?.[0];
+  if (!file) return;
+
+  const reader = new FileReader();
+  reader.onload = (e) => {
+    avatarPreview.src = e.target?.result;
+  };
+  reader.readAsDataURL(file);
+});
+
+// Pomodoro timer logic
+const WORK_DURATION = 25 * 60;
+const BREAK_DURATION = 5 * 60;
+let isWorkSession = true;
+let remainingSeconds = WORK_DURATION;
+let timerInterval = null;
+
+const timerValueEl = document.getElementById('timer-value');
+const timerLabelEl = document.querySelector('.timer-label');
+const toggleTimerBtn = document.getElementById('toggle-timer');
+const resetTimerBtn = document.getElementById('reset-timer');
+const timerProgressEl = document.querySelector('.timer-progress');
+
+function formatTime(seconds) {
+  const minutes = String(Math.floor(seconds / 60)).padStart(2, '0');
+  const secs = String(seconds % 60).padStart(2, '0');
+  return `${minutes}:${secs}`;
+}
+
+function updateTimerDisplay() {
+  timerValueEl.textContent = formatTime(remainingSeconds);
+  timerLabelEl.textContent = isWorkSession ? 'Foco' : 'Descanso';
+  const total = isWorkSession ? WORK_DURATION : BREAK_DURATION;
+  const progress = 1 - remainingSeconds / total;
+  const circumference = 2 * Math.PI * 54;
+  timerProgressEl.style.strokeDashoffset = circumference * (1 - progress);
+}
+
+function switchSession() {
+  isWorkSession = !isWorkSession;
+  remainingSeconds = isWorkSession ? WORK_DURATION : BREAK_DURATION;
+  updateTimerDisplay();
+}
+
+function tick() {
+  if (remainingSeconds > 0) {
+    remainingSeconds -= 1;
+    updateTimerDisplay();
+  } else {
+    switchSession();
+  }
+}
+
+function startTimer() {
+  if (timerInterval) return;
+  timerInterval = setInterval(tick, 1000);
+  toggleTimerBtn.textContent = 'Pausar';
+}
+
+function pauseTimer() {
+  clearInterval(timerInterval);
+  timerInterval = null;
+  toggleTimerBtn.textContent = 'Iniciar';
+}
+
+function resetTimer() {
+  pauseTimer();
+  isWorkSession = true;
+  remainingSeconds = WORK_DURATION;
+  updateTimerDisplay();
+}
+
+toggleTimerBtn?.addEventListener('click', () => {
+  if (timerInterval) {
+    pauseTimer();
+  } else {
+    startTimer();
+  }
+});
+
+resetTimerBtn?.addEventListener('click', resetTimer);
+
+renderWeeklyCalendar();
+updateDashboard();
+updateTimerDisplay();

--- a/styles.css
+++ b/styles.css
@@ -1,0 +1,556 @@
+:root {
+  --bg: #f5f7fb;
+  --card-bg: #ffffff;
+  --text: #1f2933;
+  --muted: #6b7280;
+  --primary: #6366f1;
+  --primary-soft: rgba(99, 102, 241, 0.15);
+  --todo: #f97316;
+  --progress: #0ea5e9;
+  --done: #22c55e;
+  --border: rgba(15, 23, 42, 0.08);
+  --shadow: 0 12px 24px rgba(15, 23, 42, 0.08);
+  --radius-lg: 24px;
+  --radius-md: 18px;
+  --radius-sm: 12px;
+}
+
+* {
+  box-sizing: border-box;
+  margin: 0;
+  padding: 0;
+}
+
+body {
+  font-family: 'Inter', sans-serif;
+  background: radial-gradient(circle at top left, #eef2ff 0%, #f5f7fb 45%, #ffffff 100%);
+  color: var(--text);
+  min-height: 100vh;
+  padding: 40px clamp(24px, 6vw, 64px);
+}
+
+.layout {
+  max-width: 1280px;
+  margin: 0 auto;
+  display: flex;
+  flex-direction: column;
+  gap: 32px;
+}
+
+.header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  background: var(--card-bg);
+  padding: 28px 32px;
+  border-radius: var(--radius-lg);
+  box-shadow: var(--shadow);
+}
+
+.header h1 {
+  font-size: clamp(28px, 2.8vw, 36px);
+  font-weight: 700;
+}
+
+.subtitle {
+  margin-top: 8px;
+  color: var(--muted);
+  font-size: 15px;
+}
+
+.add-task-button {
+  background: var(--primary);
+  color: #fff;
+  font-weight: 600;
+  padding: 12px 20px;
+  border-radius: var(--radius-sm);
+  border: none;
+  cursor: pointer;
+  box-shadow: 0 8px 16px rgba(99, 102, 241, 0.3);
+  transition: transform 0.2s ease, box-shadow 0.2s ease;
+}
+
+.add-task-button:hover {
+  transform: translateY(-1px);
+  box-shadow: 0 14px 24px rgba(99, 102, 241, 0.35);
+}
+
+.grid {
+  display: grid;
+  grid-template-columns: repeat(4, minmax(0, 1fr));
+  gap: 24px;
+}
+
+.card {
+  background: var(--card-bg);
+  border-radius: var(--radius-lg);
+  padding: 26px;
+  box-shadow: var(--shadow);
+  display: flex;
+  flex-direction: column;
+  gap: 24px;
+}
+
+.card-header h2 {
+  font-size: 18px;
+  font-weight: 600;
+}
+
+.card-caption {
+  display: block;
+  margin-top: 4px;
+  font-size: 13px;
+  color: var(--muted);
+}
+
+.span-2 {
+  grid-column: span 2;
+}
+
+.span-4 {
+  grid-column: span 4;
+}
+
+.progress-list {
+  display: flex;
+  flex-direction: column;
+  gap: 18px;
+}
+
+.progress-item {
+  display: grid;
+  grid-template-columns: 120px 1fr 64px;
+  align-items: center;
+  gap: 16px;
+}
+
+.progress-label {
+  font-weight: 600;
+}
+
+.progress-bar {
+  position: relative;
+  height: 12px;
+  border-radius: 999px;
+  background: var(--primary-soft);
+  overflow: hidden;
+}
+
+.progress-fill {
+  position: absolute;
+  top: 0;
+  left: 0;
+  bottom: 0;
+  border-radius: inherit;
+  transition: width 0.4s ease;
+}
+
+.progress-value {
+  font-weight: 600;
+  text-align: right;
+  color: var(--muted);
+}
+
+.counter-grid {
+  display: grid;
+  grid-template-columns: repeat(3, minmax(0, 1fr));
+  gap: 16px;
+}
+
+.counter-item {
+  background: linear-gradient(145deg, rgba(99, 102, 241, 0.08), rgba(99, 102, 241, 0));
+  padding: 16px;
+  border-radius: var(--radius-md);
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+}
+
+.counter-label {
+  color: var(--muted);
+  font-size: 13px;
+}
+
+.counter-value {
+  font-size: 24px;
+  font-weight: 700;
+}
+
+.avatar-wrapper {
+  display: flex;
+  flex-direction: column;
+  gap: 16px;
+}
+
+.avatar-upload {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 14px;
+  cursor: pointer;
+}
+
+.avatar-upload img {
+  width: 120px;
+  height: 120px;
+  border-radius: 50%;
+  object-fit: cover;
+  border: 4px solid rgba(99, 102, 241, 0.2);
+  box-shadow: inset 0 0 0 4px #fff, 0 8px 24px rgba(99, 102, 241, 0.15);
+  transition: transform 0.3s ease;
+}
+
+.avatar-upload:hover img {
+  transform: scale(1.02);
+}
+
+.avatar-upload span {
+  font-weight: 500;
+  color: var(--primary);
+}
+
+#avatar-input {
+  display: none;
+}
+
+.week-calendar {
+  display: grid;
+  grid-template-columns: repeat(5, minmax(0, 1fr));
+  gap: 16px;
+}
+
+.week-day {
+  padding: 16px;
+  border-radius: var(--radius-md);
+  background: rgba(148, 163, 184, 0.12);
+  position: relative;
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+  text-align: center;
+}
+
+.week-day.current {
+  background: rgba(99, 102, 241, 0.18);
+  border: 1px solid rgba(99, 102, 241, 0.3);
+}
+
+.week-day strong {
+  font-size: 15px;
+}
+
+.week-day span {
+  font-size: 13px;
+  color: var(--muted);
+}
+
+.pomodoro {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 18px;
+}
+
+.timer-display {
+  position: relative;
+  width: 180px;
+  height: 180px;
+  display: grid;
+  place-items: center;
+}
+
+.timer-ring {
+  width: 180px;
+  height: 180px;
+  transform: rotate(-90deg);
+}
+
+.timer-track {
+  fill: none;
+  stroke: rgba(99, 102, 241, 0.15);
+  stroke-width: 10;
+}
+
+.timer-progress {
+  fill: none;
+  stroke: var(--primary);
+  stroke-width: 10;
+  stroke-linecap: round;
+  stroke-dasharray: 339.292;
+  stroke-dashoffset: 0;
+  transition: stroke-dashoffset 0.3s ease;
+}
+
+.timer-info {
+  position: absolute;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 4px;
+}
+
+.timer-label {
+  font-size: 14px;
+  color: var(--muted);
+}
+
+.timer-value {
+  font-size: 32px;
+  font-weight: 700;
+}
+
+.timer-controls {
+  display: flex;
+  gap: 12px;
+}
+
+button {
+  font-family: inherit;
+}
+
+button.ghost {
+  background: transparent;
+  color: var(--primary);
+  border: 1px solid rgba(99, 102, 241, 0.4);
+  padding: 10px 16px;
+  border-radius: var(--radius-sm);
+  cursor: pointer;
+  font-weight: 600;
+}
+
+button.ghost:hover {
+  background: rgba(99, 102, 241, 0.08);
+}
+
+.percent-wrapper {
+  display: flex;
+  align-items: center;
+  gap: 32px;
+  flex-wrap: wrap;
+}
+
+.donut {
+  position: relative;
+  width: 220px;
+  height: 220px;
+  border-radius: 50%;
+  background: conic-gradient(var(--primary) 0deg, var(--primary) 360deg);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+}
+
+.donut::after {
+  content: '';
+  position: absolute;
+  width: 150px;
+  height: 150px;
+  border-radius: 50%;
+  background: var(--card-bg);
+}
+
+.donut-center {
+  position: relative;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 2px;
+  text-align: center;
+}
+
+.legend {
+  list-style: none;
+  display: grid;
+  gap: 12px;
+}
+
+.legend-item {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+}
+
+.legend-bullet {
+  width: 14px;
+  height: 14px;
+  border-radius: 4px;
+}
+
+.legend-text {
+  display: flex;
+  flex-direction: column;
+  gap: 2px;
+}
+
+.legend-text span {
+  font-size: 12px;
+  color: var(--muted);
+}
+
+.task-form {
+  background: rgba(99, 102, 241, 0.06);
+  border-radius: var(--radius-md);
+  padding: 20px;
+  display: flex;
+  flex-direction: column;
+  gap: 18px;
+}
+
+.form-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(180px, 1fr));
+  gap: 16px 18px;
+}
+
+label {
+  font-size: 13px;
+  font-weight: 600;
+  color: var(--muted);
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+}
+
+input[type='text'],
+input[type='time'],
+select {
+  padding: 10px 12px;
+  border-radius: var(--radius-sm);
+  border: 1px solid rgba(148, 163, 184, 0.4);
+  font-size: 14px;
+  color: var(--text);
+  background: #fff;
+}
+
+input:focus,
+select:focus {
+  outline: 2px solid rgba(99, 102, 241, 0.4);
+  border-color: transparent;
+}
+
+.form-actions {
+  display: flex;
+  justify-content: flex-end;
+  gap: 12px;
+}
+
+.form-actions button[type='submit'] {
+  background: var(--primary);
+  color: #fff;
+  border: none;
+  border-radius: var(--radius-sm);
+  padding: 10px 20px;
+  font-weight: 600;
+  cursor: pointer;
+}
+
+.agenda {
+  display: grid;
+  gap: 16px;
+}
+
+.agenda-day {
+  background: rgba(15, 23, 42, 0.04);
+  border-radius: var(--radius-md);
+  padding: 16px;
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+}
+
+.agenda-day header {
+  display: flex;
+  justify-content: space-between;
+  align-items: baseline;
+}
+
+.agenda-day header h3 {
+  font-size: 16px;
+}
+
+.agenda-day header span {
+  font-size: 12px;
+  color: var(--muted);
+}
+
+.task-item {
+  display: grid;
+  grid-template-columns: 1fr 140px 110px;
+  gap: 12px;
+  align-items: center;
+  background: #fff;
+  padding: 12px 14px;
+  border-radius: var(--radius-sm);
+  box-shadow: inset 0 0 0 1px rgba(15, 23, 42, 0.05);
+}
+
+.task-name {
+  font-weight: 600;
+}
+
+.task-time {
+  font-size: 13px;
+  color: var(--muted);
+}
+
+.task-item select {
+  border-radius: var(--radius-sm);
+}
+
+@media (max-width: 1100px) {
+  .grid {
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+  }
+
+  .span-4 {
+    grid-column: span 2;
+  }
+
+  .counter-grid {
+    grid-template-columns: repeat(auto-fit, minmax(120px, 1fr));
+  }
+
+  .week-calendar {
+    grid-template-columns: repeat(auto-fit, minmax(140px, 1fr));
+  }
+
+  .progress-item {
+    grid-template-columns: 1fr;
+    gap: 8px;
+  }
+
+  .progress-value {
+    text-align: left;
+  }
+}
+
+@media (max-width: 720px) {
+  body {
+    padding: 24px 16px 64px;
+  }
+
+  .grid {
+    grid-template-columns: 1fr;
+  }
+
+  .header {
+    flex-direction: column;
+    align-items: flex-start;
+    gap: 16px;
+  }
+
+  .span-2,
+  .span-4 {
+    grid-column: span 1;
+  }
+
+  .task-item {
+    grid-template-columns: 1fr;
+    gap: 8px;
+    align-items: flex-start;
+  }
+
+  .task-item select {
+    width: 100%;
+  }
+}


### PR DESCRIPTION
## Summary
- add responsive dashboard layout for to-do tracking with header, status cards, profile and agenda modules
- style the interface with modern card-based visuals, gradients, and responsive grid behavior
- implement dynamic task management, progress indicators, avatar upload, and Pomodoro timer interactions

## Testing
- No automated tests were run (not applicable)


------
https://chatgpt.com/codex/tasks/task_e_68db63c7efb8832f82e8b8a496d230b2